### PR TITLE
feat: new cranio-emx2 setup script

### DIFF
--- a/erns/cranio/emx2_init_demo.sh
+++ b/erns/cranio/emx2_init_demo.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
+HOST=''
+USER_NAME=''
+USER_PASS=''
 
-HOST=""
-USER_NAME=""
-USER_PASS=""
 
-# ////////////////////////////////////////////////////////////////////////////
-
-# ~ 1 ~
 # sign in and retrieve token for sending additional requests and clean up molgenis instance
 # NOTE: Set username and password
 TOKEN=$(curl -s "${HOST}/api/graphql" \
@@ -31,14 +28,14 @@ do
     -d '{"query":"mutation{deleteSchema(id:\"'${SCHEMA}'\"){message}}"}'
 done
 
-# ////////////////////////////////////////////////////////////////////////////
 
-# ~ 3 ~
+
 # Create new schema from ERN_DASHBOARD: the schema name is hard coded into the vue apps
 curl "${HOST}/api/graphql" \
   -H "x-molgenis-token:${TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{"query":"mutation{createSchema(name:\"CranioStats\",description:\"ERN CRANIO MASTER\",template:\"ERN_DASHBOARD\"){message}}"}'
+
 
 # import data
 curl "${HOST}/CranioStats/api/excel" \
@@ -57,9 +54,8 @@ curl -s "${HOST}/CranioStats/api/graphql" \
   -H "x-molgenis-token:${TOKEN}" \
   -d '{"query": "mutation{change(settings:[{key:\"menu\",value:\"'${PUBLIC_MENU}'\"}]){message}}"}'
 
-# ////////////////////////////////////////////////////////////////////////////
-  
-# ~ 4 ~
+
+
 # Creating a new schemas using the 7 starting institutions + Erasmus
 # create empty schema (replace with template later) and make the schema viewable as anonymous
 
@@ -118,7 +114,6 @@ do
   ((INDEX++))
 done
 
-# ////////////////////////////////////////////////////////////////////////////
 
 # ~ 99 ~ 
 # Update Schema Descriptions

--- a/erns/cranio/emx2_init_demo.sh
+++ b/erns/cranio/emx2_init_demo.sh
@@ -82,7 +82,7 @@ declare -a SCHEMA_NAMES=(
   "University Hospital Motol "
   "Charité Universitätsmedizin Berlin"
   "Szent-Györgyi Albert Medical Center, University of Szeged"
-  "Fondazione Policlinico Universitario A. Gemelli "
+  "Fondazione Policlinico Universitario A. Gemelli"
   "San Gerardo Hospital"
   "Vilnius University Hospital"
   "Erasmus MC"

--- a/erns/cranio/emx2_menus.json
+++ b/erns/cranio/emx2_menus.json
@@ -1,0 +1,98 @@
+{
+  "public": [
+    {
+        "label": "Home",
+        "href": "./cranio-public",
+        "role": "Viewer"
+    },
+    {
+      "label": "Tables",
+      "href": "tables",
+      "role": "Viewer"
+    },
+    {
+      "label": "Schema",
+      "href": "schema",
+      "role": "Manager"
+    },
+    {
+      "label": "Up/Download",
+      "href": "updownload",
+      "role": "Editor"
+    },
+    {
+      "label": "Graphql",
+      "href": "graphql-playground",
+      "role": "Editor"
+    },
+    {
+      "label": "Settings",
+      "href": "settings",
+      "role": "Manager"
+    },
+    {
+      "label": "Help",
+      "href": "docs",
+      "role": "Viewer"
+    }
+  ],
+  "provider": [
+    {
+      "label": "Home",
+      "href": "./cranio-public",
+      "role": "Viewer"
+    },
+    {
+      "label": "Patients",
+      "href": "tables/#/Subject",
+      "role": "Editor"
+    },
+    {
+      "label": "Visit per workstream",
+      "href": "",
+      "submenu": [
+        {
+          "label": "CRANIOSYNOSTOSIS workstream",
+          "href": "tables/#/Visits_synostosis",
+          "role": "Editor"
+        },
+        {
+          "label": "CLEFT workstream",
+          "href": "tables/#/Visits_cleft",
+          "role": "Editor"
+        }
+      ],
+      "role": "Editor"
+    },
+    {
+      "label": "Tables",
+      "href": "tables",
+      "role": "Viewer"
+    },
+    {
+      "label": "Schema",
+      "href": "schema",
+      "role": "Manager"
+    },
+    {
+      "label": "Up/Download",
+      "href": "updownload",
+      "role": "Editor"
+    },
+    {
+      "label": "Graphql",
+      "href": "graphql-playground",
+      "role": "Viewer"
+    },
+    {
+      "label": "Settings",
+      "href": "settings",
+      "role": "Manager"
+    },
+    {
+      "label": "Help",
+      "href": "docs",
+      "role": "Viewer"
+    }
+  ]
+}

--- a/erns/cranio/emx2_setup.sh
+++ b/erns/cranio/emx2_setup.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+emx2_host=''
+user_email=''
+user_password=''
+target_schema='cli_schema_test'
+
+# ////////////////////////////////////////////////////////////////////////////
+
+# Create functions that generate new GraphQL queries
+new_signin_query () {
+    local email=$1
+    local password=$2
+    query='mutation {
+        signin (email: "'$email'", password: "'$password'") {
+            status
+            message
+            token
+        }
+    }'
+    echo $query
+}
+
+new_create_schema_query () {
+    local name=$1
+    local description=$2
+    query='mutation {
+        createSchema (name: "'$name'", description: "'$description'") {
+            status
+            message
+        }
+    }'
+    echo $query
+}
+
+new_update_schema_query () {
+    local name=$1
+    local description=$2
+    query='mutation {
+        createSchema (name: "'$name'", description: "'$description'") {
+            status
+            message
+        }
+    }'
+    echo $query
+}
+
+new_delete_schema_query () {
+    local name=$1
+    query='mutation {
+        deleteSchema (name: "'$name'") {
+            status
+            message
+        }
+    }'
+    echo $query
+}
+
+new_change_members_query () {
+    local email=$1
+    local role=$2
+    query='mutation {
+        change (members: [{email:"'$email'", role:"'$role'"}]) {
+            status
+            message
+        }
+    }'
+    echo $query
+}
+
+new_change_setting_query () {
+    local setting=$1
+    local value=$2
+    query='mutation {
+        change (settings:[{key: "'$setting'", value: '$value'}]) {
+            status
+            message
+        }
+    }'
+    echo $query
+}
+
+# ////////////////////////////////////////////////////////////////////////////
+
+
+# sign in and get token
+
+signin_gql=$(new_signin_query $user_email $user_password)
+api_token=$(curl "${emx2_host}/api/graphql" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -c -n --arg query "$signin_gql" '{"query": $query}')" \
+    | grep "token" | tr -d '"' | awk '{print $3}'
+)
+
+echo $api_token
+
+#~~~~~~~~~~~~~~
+# ~ OPTIONAL ~
+# remove existing schemas
+declare -a schemas_to_remove=(
+  "catalogue-demo"
+  "CatalogueOntologies"
+  "pet store"
+)
+
+for schema in "${schemas_to_remove[@]}"
+do
+  delete_schema_gql=$(new_delete_schema_query $SCHEMA)
+    curl -s "${emx2_host}/api/graphql" \
+        -H "x-molgenis-token:${api_token}" \
+        -H "Content-Type: application/json" \
+        -d "$(jq -c -n --arg query "$delete_schema_gql" '{"query": $query}')"
+done
+#~~~~~~~~~~~~~~
+  
+
+# create a schema
+create_schema_gql=$(new_create_schema_query $target_schema "created by curl")
+curl "${emx2_host}/api/graphql" \
+    -H "x-molgenis-token:${api_token}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -c -n --arg query "$create_schema_gql" '{"query": $query}')"
+
+
+# update the menu
+public_menu=$(jq '.public | tostring' erns/cranio/emx2_menus.json)
+set_menu_gql=$(new_change_setting_query "menu" $public_menu)
+menu_payload="$(jq -c -n --arg query "$set_menu_gql" '{"query": $query}')"
+echo $menu_payload
+ 
+curl -s "${emx2_host}/${target_schema}/api/graphql" \
+    -H "Content-Type: application/json" \
+    -H "x-molgenis-token:${api_token}" \
+    -d $menu_payload
+
+
+
+# add anonymous user
+add_member_gql=$(new_change_members_query 'anonymous' 'Viewer')
+curl "${emx2_host}/${target_schema}/api/graphql" \
+    -H "x-molgenis-token:${api_token}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -c -n --arg query "$add_member_gql" '{"query": $query}')"

--- a/erns/cranio/emx2_setup.sh
+++ b/erns/cranio/emx2_setup.sh
@@ -106,18 +106,21 @@ for schema in "${schemas_to_remove[@]}"
 do
   delete_schema_gql=$(new_delete_schema_query $SCHEMA)
     curl -s "${emx2_host}/api/graphql" \
-        -H "x-molgenis-token:${api_token}" \
         -H "Content-Type: application/json" \
+        -H "x-molgenis-token:${api_token}" \
         -d "$(jq -c -n --arg query "$delete_schema_gql" '{"query": $query}')"
 done
-#~~~~~~~~~~~~~~
+
   
+# //////////////////////////////////////
+
+# init primary schema - load menu, change membership, add description
 
 # create a schema
 create_schema_gql=$(new_create_schema_query $target_schema "created by curl")
 curl "${emx2_host}/api/graphql" \
-    -H "x-molgenis-token:${api_token}" \
     -H "Content-Type: application/json" \
+    -H "x-molgenis-token:${api_token}" \
     -d "$(jq -c -n --arg query "$create_schema_gql" '{"query": $query}')"
 
 
@@ -126,17 +129,61 @@ public_menu=$(jq '.public | tostring' erns/cranio/emx2_menus.json)
 set_menu_gql=$(new_change_setting_query "menu" $public_menu)
 menu_payload="$(jq -c -n --arg query "$set_menu_gql" '{"query": $query}')"
 echo $menu_payload
- 
+
 curl -s "${emx2_host}/${target_schema}/api/graphql" \
     -H "Content-Type: application/json" \
     -H "x-molgenis-token:${api_token}" \
     -d $menu_payload
 
 
-
 # add anonymous user
 add_member_gql=$(new_change_members_query 'anonymous' 'Viewer')
 curl "${emx2_host}/${target_schema}/api/graphql" \
-    -H "x-molgenis-token:${api_token}" \
     -H "Content-Type: application/json" \
+    -H "x-molgenis-token:${api_token}" \
     -d "$(jq -c -n --arg query "$add_member_gql" '{"query": $query}')"
+    
+    
+# update description
+update_desc=$(new_update_schema_query $target_schema "created by curl")
+
+# //////////////////////////////////////
+
+# create schemas for organisations
+
+# create payload for menu
+provider_menu=$(jq '.provider | tostring' erns/cranio/emx2_menus.json)
+org_menu_gql=$(new_change_setting_query "menu" $provider_menu)
+org_menu_payload=$(jq -c -n --arg query "$org_menu_gql" '{"query": $query}')
+echo $org_menu_payload
+
+
+organisations_json=erns/cranio/emx2_setup_orgs.json
+jq -c '.organisations[]' $organisations_json | while read row; do
+    org_id=$(jq '.id' <<< $row)
+    org_name=$(jq '.name' <<< $row)
+  
+    org_create_schema=$(new_create_schema_query $org_id $org_name)
+    org_update_schema=$(new_update_schema_query $org_id $org_name)
+    
+    curl "${emx2_host}/api/graphql" \
+        -H "Content-Type: application/json" \
+        -H "x-molgenis-token:${api_token}" \
+        -d "$(jq -c -n --arg query "$org_create_schema" '{"query": $query}')"
+    
+    curl "${emx2_host}/{$org_id}/api/graphql" \
+        -H "Content-Type: application/json" \
+        -H "x-molgenis-token:${api_token}" \
+        -d $org_menu_payload
+        
+    curl "${emx2_host}/${target_schema}/api/graphql" \
+        -H "Content-Type: application/json" \
+        -H "x-molgenis-token:${api_token}" \
+        -d "$(jq -c -n --arg query "$add_member_gql" '{"query": $query}')"
+    
+    curl "${emx2_host}/${target_schema}/api/graphql" \
+        -H "Content-Type: application/json" \
+        -H "x-molgenis-token:${api_token}" \
+        -d "$(jq -c -n --arg query "$org_update_query" '{"query": $query}')"
+    
+done

--- a/erns/cranio/emx2_setup_orgs.json
+++ b/erns/cranio/emx2_setup_orgs.json
@@ -1,0 +1,48 @@
+{
+  "organisations": [
+    {
+      "id": "BE1",
+      "name": "Antwerp University Hospital"
+    },
+    {
+      "id": "BE3",
+      "name": "UZ Leuven"
+    },
+    {
+      "id": "CZ1",
+      "name": "University Hospital Motol"
+    },
+    {
+      "id": "DE1",
+      "name": "Charité Universitätsmedizin Berlin"
+    },
+    {
+      "id": "HU1",
+      "name": "Szent-Györgyi Albert Medical Center, University of Szeged"
+    },
+    {
+      "id": "IT4",
+      "name": "Fondazione Policlinico Universitario A. Gemelli"
+    },
+    {
+      "id": "IT6",
+      "name": "San Gerardo Hospital"
+    },
+    {
+      "id": "LT1",
+      "name": "Vilnius University Hospital"
+    },
+    {
+      "id": "NL2",
+      "name": "Erasmus MC"
+    },
+    {
+      "id": "NL4",
+      "name": "UMC Utrecht"
+    },
+    {
+      "id": "NO2",
+      "name": "Oslo University Hospital"
+    }
+  ]
+}


### PR DESCRIPTION
The previous method is a bit clunky and prone to errors, especially when updating the menus. Ideally, the menu object should be stored in a json file and incorporated into the GraphQL query generation. Since the script reuses a lot of code, it would be nice to rewrite code as functions. It would also be a good moment to incorporate the `jq` command line tool to make data handling easier. This request includes the following changes to the cranio setup script:

- [x] Rewrite script and Incorporate the jq command line tool
- [x] Rewrite GraphQL queries as functions
- [x] Store public and provider menus in a json file
- [x] Improve the organisation-level schema commands (create, update, change, etc.)